### PR TITLE
Moved prop-types dependency into it's own package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { View, Animated, StyleSheet, Dimensions, Image } from 'react-native';
+import PropTypes from 'prop-types';
 
 const { width: deviceWidth, height: deviceHeight } = Dimensions.get('window');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-parallax-swiper",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Full Screen Parallax Swiper Allowing Arbitrary UI Injection",
   "main": "index.js",
   "repository": {
@@ -35,7 +35,10 @@
     "eslint-plugin-react-native": "^2.3.2"
   },
   "peerDependencies": {
-    "react": "~15.3.1",
-    "react-native": "0.37.0"
+    "react": "^15.3.1",
+    "react-native": "^0.37.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.7"
   }
 }


### PR DESCRIPTION
Moved prop-types dependency into it's own package, this is required by react-native 0.48.0+.