### PR TITLE
Update ParallaxSwiper.js

### DIFF
--- a/src/ParallaxSwiper.js
+++ b/src/ParallaxSwiper.js
@@ -6,7 +6,7 @@ import ParallaxSwiperPage, {
   ParallaxSwiperPagePropTypes,
 } from './ParallaxSwiperPage';
 
-const { width: deviceWidth, height: deviceHeight } = Dimensions.get('window');
+const { width: deviceWidth, height: deviceHeight } = Dimensions.get('screen');
 
 class ParallaxSwiper extends Component {
   state = {


### PR DESCRIPTION
Changing 'window' to 'screen' to get the right screen in xaiomi devices